### PR TITLE
sync list of db emails with a table id

### DIFF
--- a/BE/rest/controllers/list/controller.ts
+++ b/BE/rest/controllers/list/controller.ts
@@ -63,33 +63,21 @@ listRouter.get("/createtable", async (_req, res) => {
 });
 
 listRouter.get("/synctable", async (_req, res) => {
+  const mailingListId = 3;
+  const mailingListRecipients = await getMailingListDetails(mailingListId);
+  //   get list of emails in grist table,
+  //   get list of emails from mailing list
+  //    and remove the emails that are not in the mailing list
+  //   add the emails that are in the mailing list but not in the grist table
+  //   delete the emails from the grist table that are not in the mailing list
+  //   to delete: get the ids of the rows that need to be removed
+  //
+
   const dataToADD = {
-    records: [
-      {
-        require: {
-          email: "cat@mail.com",
-        },
-        fields: {
-          name: "cat",
-        },
-      },
-      {
-        require: {
-          email: "bob@mail.com",
-        },
-        fields: {
-          name: "bob",
-        },
-      },
-      {
-        require: {
-          email: "doggy@mail.com",
-        },
-        fields: {
-          name: "doggy",
-        },
-      },
-    ],
+    records: mailingListRecipients.map((email) => ({
+      require: { email },
+      fields: { name: email.split("@")[0] }, // Create a name from the email before the @ symbol
+    })),
   };
   try {
     const allTables = await syncGristTable(docId, "9", dataToADD);

--- a/BE/rest/controllers/list/grist.ts
+++ b/BE/rest/controllers/list/grist.ts
@@ -119,6 +119,7 @@ export const syncGristTable = async (
   tableId: string,
   dataToADD: any
 ) => {
+  // filter the data before adding
   return new Promise((resolve, reject) => {
     const options = {
       host: "docs.getgrist.com",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit eaaadea53963e1a6226562f537b8c6a5f270ec95  | 
|--------|--------|

### Summary:
Added functionality to sync a list of emails from a database with a Grist table in the `/synctable` endpoint.

**Key points**:
- Updated `listRouter.get('/synctable')` in `BE/rest/controllers/list/controller.ts` to sync emails from a mailing list to a Grist table.
- Fetches mailing list details using `getMailingListDetails`.
- Maps emails to the required format for Grist table.
- Calls `syncGristTable` to update the Grist table.
- Added comments for future improvements and clarifications.
- Updated `syncGristTable` in `BE/rest/controllers/list/grist.ts` to handle data synchronization.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->