### PR TITLE
create grist table with new mailing list

### DIFF
--- a/BE/prisma/mailinglistFunctions.ts
+++ b/BE/prisma/mailinglistFunctions.ts
@@ -1,5 +1,7 @@
 import { PrismaClient, Sender } from "@prisma/client";
+import { createGristTable } from "../rest/controllers/list/grist";
 const prisma = new PrismaClient();
+const docId = "jwCdg4Ffpuag";
 
 // export async function main() {
 export const createNewMailingList = async (
@@ -24,6 +26,30 @@ export const createNewMailingList = async (
     })
   );
 
+  // create a new grist table, get the id and attach it to the mailing list
+  const dataToADD = {
+    tables: [
+      {
+        id: mailinglistName,
+        columns: [
+          {
+            id: "email",
+            fields: {
+              label: "Email",
+            },
+          },
+          {
+            id: "name",
+            fields: {
+              label: "Name",
+            },
+          },
+        ],
+      },
+    ],
+  };
+  const gristTable = await createGristTable(docId, dataToADD);
+
   return await prisma.mailingList.create({
     data: {
       name: mailinglistName,
@@ -31,6 +57,7 @@ export const createNewMailingList = async (
       recipients: {
         connect: recipientsData,
       },
+      gristTableId: Number(gristTable.id),
     },
   });
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ee98b517f83b2917f0a4bd41f4499c110987bdf4  | 
|--------|--------|

### Summary:
Added functionality to create a new Grist table when a new mailing list is created and attach the Grist table ID to the mailing list in the database.

**Key points**:
- Updated `BE/prisma/mailinglistFunctions.ts` to create a new Grist table when a new mailing list is created.
- Added `createGristTable` import from `../rest/controllers/list/grist`.
- Defined `docId` constant for Grist document ID.
- Modified `createNewMailingList` function to include Grist table creation logic.
- Attached the Grist table ID to the new mailing list in the database.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->